### PR TITLE
Add simple README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# DH Bridge Workshop
+
+## Getting Started
+
+DHBridge uses `middleman` to manage the curriculum web pages. 
+
+```
+$ bundle install
+```
+
+## Running
+
+To start the web server, simply type `middleman` in the terminal. This
+will start a web server with the website to preview at
+http://localhost:4567/.


### PR DESCRIPTION
Adds simple readme for people unfamiliar with middleman to run their own version of the curriculum site.

closes #10
